### PR TITLE
update spark SA and role

### DIFF
--- a/spark-operator/spark-rbac.yaml
+++ b/spark-operator/spark-rbac.yaml
@@ -1,19 +1,37 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: spark
+  name: spark-operator-spark
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: spark-role
 rules:
-- apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["*"]
-- apiGroups: [""]
-  resources: ["services"]
-  verbs: ["*"]
+  - verbs:
+      - '*'
+    apiGroups:
+      - ''
+    resources:
+      - pods
+  - verbs:
+      - '*'
+    apiGroups:
+      - ''
+    resources:
+      - services
+  - verbs:
+      - '*'
+    apiGroups:
+      - ''
+    resources:
+      - configmaps
+  - verbs:
+      - '*'
+    apiGroups:
+      - ''
+    resources:
+      - persistentvolumeclaims
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -21,7 +39,7 @@ metadata:
   name: spark-role-binding
 subjects:
 - kind: ServiceAccount
-  name: spark
+  name: spark-operator-spark
 roleRef:
   kind: Role
   name: spark-role


### PR DESCRIPTION
This updates the SA used in the instructions for running a sparkApplication from another namespace to match the SA that is being utilized in the test SparkApplications.

It also updates the spark-role to match the permissions that the helm chart is granting in the latest version.