### PR TITLE
Update the Spark-Operator Helm Repository

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -166,7 +166,7 @@ We can use the standard version of the Spark on Kubernetes Operator at its lates
 .Add the helm repo
 [source,bash]
 ----
-helm repo add spark-operator https://googlecloudplatform.github.io/spark-on-k8s-operator
+helm repo add spark-operator https://kubeflow.github.io/spark-operator/
 ----
 
 .Deploy the helm chart


### PR DESCRIPTION
The Helm repository has moved from googlecloud to kubeflow (https://github.com/kubeflow/spark-operator/issues/1944)