### PR TITLE
Migrate instructions to Kubeflow Spark

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -173,7 +173,10 @@ helm repo update
 .Deploy the helm chart
 [source,bash]
 ----
-helm install spark-operator spark-operator/spark-operator --namespace spark-operator  --create-namespace --set webhook.enable=true --set resourceQuotaEnforcement.enable=true 
+helm install spark-operator spark-operator/spark-operator /
+  --namespace spark-operator  --create-namespace /
+  --set webhook.enable=true /
+  --set resourceQuotaEnforcement.enable=true 
 ----
 
 ==== Spark Monitoring (Optional)

--- a/README.adoc
+++ b/README.adoc
@@ -173,7 +173,7 @@ helm repo update
 .Deploy the helm chart
 [source,bash]
 ----
-helm install spark-operator spark-operator/spark-operator --namespace spark-operator  --create-namespace  --set image.tag=v1beta2-1.3.3-3.1.1 --set webhook.enable=true --set resourceQuotaEnforcement.enable=true 
+helm install spark-operator spark-operator/spark-operator --namespace spark-operator  --create-namespace --set webhook.enable=true --set resourceQuotaEnforcement.enable=true 
 ----
 
 ==== Spark Monitoring (Optional)

--- a/README.adoc
+++ b/README.adoc
@@ -166,7 +166,8 @@ We can use the standard version of the Spark on Kubernetes Operator at its lates
 .Add the helm repo
 [source,bash]
 ----
-helm repo add spark-operator https://googlecloudplatform.github.io/spark-on-k8s-operator
+helm repo add spark-operator https://kubeflow.github.io/spark-operator
+helm repo update
 ----
 
 .Deploy the helm chart


### PR DESCRIPTION
It looks like the Google Spark Operator we were previously referencing has moved over to the Kubeflow umbrella and some of the links like the helm repo no longer exist.

This PR updates some of those links.